### PR TITLE
Fix removal of builds and branches

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -187,8 +187,8 @@ public class BitbucketServerAPIClient implements BitbucketApi {
             return pullRequests;
         } catch (IOException e) {
             LOGGER.log(Level.SEVERE, "invalid pull requests response", e);
+            throw new BitbucketRequestException(0, "invalid pull requests response" + e, e);
         }
-        return Collections.EMPTY_LIST;
     }
 
     /** {@inheritDoc} */
@@ -199,8 +199,8 @@ public class BitbucketServerAPIClient implements BitbucketApi {
             return parse(response, BitbucketServerPullRequest.class);
         } catch (IOException e) {
             LOGGER.log(Level.WARNING, "invalid pull request response.", e);
+            throw new BitbucketRequestException(0, "invalid pull request response." + e, e);
         }
-        return null;
     }
 
     /** {@inheritDoc} */
@@ -214,8 +214,8 @@ public class BitbucketServerAPIClient implements BitbucketApi {
             return parse(response, BitbucketServerRepository.class);
         } catch (IOException e) {
             LOGGER.log(Level.WARNING, "invalid repository response.", e);
+            throw new BitbucketRequestException(0, "invalid repository response." + e, e);
         }
-        return null;
     }
 
     /** {@inheritDoc} */
@@ -267,8 +267,8 @@ public class BitbucketServerAPIClient implements BitbucketApi {
             return branches;
         } catch (IOException e) {
             LOGGER.log(Level.SEVERE, "invalid branches response", e);
+            throw new BitbucketRequestException(0, "invalid branches response: " + e, e);
         }
-        return Collections.EMPTY_LIST;
     }
 
     /** {@inheritDoc} */
@@ -279,8 +279,8 @@ public class BitbucketServerAPIClient implements BitbucketApi {
             return parse(response, BitbucketServerCommit.class);
         } catch (IOException e) {
             LOGGER.log(Level.WARNING, "invalid commit response.", e);
+            throw new BitbucketRequestException(0, "invalid commit response." + e, e);
         }
-        return null;
     }
 
     /** {@inheritDoc} */
@@ -318,8 +318,8 @@ public class BitbucketServerAPIClient implements BitbucketApi {
                 return parse(response, BitbucketServerProject.class);
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, "invalid project response.", e);
+                throw new BitbucketRequestException(0, "invalid project response." + e, e);
             }
-            return null;
         }
     }
 
@@ -344,9 +344,9 @@ public class BitbucketServerAPIClient implements BitbucketApi {
             }
             return repositories;
         } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, "invalid branches response", e);
+            LOGGER.log(Level.SEVERE, "invalid repositories response", e);
+            throw new BitbucketRequestException(0, "invalid repositories response" + e, e);
         }
-        return Collections.EMPTY_LIST;
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
When the BitbucketServer returns something that isn't valid json for the
get methods in BitbucketServerAPIClient, those methods were returning
null. This is effectively interpreted above as there being none of the
objects we were looking for thus causing branches, PRs etc to be
trimmed erroneously. We need to throw a exception instead.